### PR TITLE
Fix case identifier fallback and tests

### DIFF
--- a/CourtListenerHelper.py
+++ b/CourtListenerHelper.py
@@ -143,6 +143,19 @@ class CommandLineInterface:
         main(args.keywords, args.output, searcher, downloader)
 
 
+def get_case_id(meta: Dict) -> str:
+    """Return a stable identifier from case metadata.
+
+    The CourtListener search API may provide different identifier fields. This
+    helper checks common keys in priority order and returns the first one
+    found. A ``KeyError`` is raised if no suitable identifier exists.
+    """
+    for key in ("id", "cluster_id", "docket_id"):
+        if key in meta:
+            return str(meta[key])
+    raise KeyError("No case identifier found in metadata")
+
+
 def sanitize_filename(name: str) -> str:
     """Return a filesystem-safe version of ``name`` suitable for saving files."""
     return "".join(c if c.isalnum() or c in " _-" else "_" for c in name)
@@ -169,7 +182,7 @@ def main(
         logger.info("\U0001F50D Searching cases for '%s' …", keyword)
         # Iterate over all pages of search results
         for case_meta in searcher.search(keyword):
-            case_id = case_meta["id"]
+            case_id = get_case_id(case_meta)
             case_url = case_meta["url"]
             case_name = case_meta.get("name", f"case_{case_id}")
             safe_name = sanitize_filename(case_name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,13 @@ import types
 import pytest
 from unittest.mock import MagicMock
 
-from CourtListenerHelper import sanitize_filename, ApiClient, CaseSearcher, CaseDownloader
+from CourtListenerHelper import (
+    sanitize_filename,
+    ApiClient,
+    CaseSearcher,
+    CaseDownloader,
+    get_case_id,
+)
 
 
 def test_sanitize_filename_simple():
@@ -73,4 +79,13 @@ def test_case_downloader_download():
     result = downloader.download('/case/1')
     assert result == {'foo': 'bar'}
     mock_client.get.assert_called_with('/case/1')
+
+
+def test_get_case_id_variants():
+    meta = {'id': 1, 'cluster_id': 2, 'docket_id': 3}
+    assert get_case_id(meta) == '1'
+    meta = {'cluster_id': 2, 'docket_id': 3}
+    assert get_case_id(meta) == '2'
+    meta = {'docket_id': 3}
+    assert get_case_id(meta) == '3'
 


### PR DESCRIPTION
## Summary
- add `get_case_id` helper to handle missing `id` fields
- use the helper in `main` when determining filenames
- cover new behaviour with tests for cluster_id support
- test fallback logic of `get_case_id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ebc855c8c832caf2c584ebb75ed7f