### PR TITLE
Fix absolute API URL handling

### DIFF
--- a/CourtListenerHelper.py
+++ b/CourtListenerHelper.py
@@ -46,7 +46,10 @@ class ApiClient:
         """Perform a GET request with basic retry and metric collection."""
         if params is None:
             params = {}
-        url = f"{self.base_url}{path}"
+        if path.startswith("http"):
+            url = path
+        else:
+            url = f"{self.base_url}{path}"
         retries = 0
         while True:
             # Measure duration so we can record API timing metrics
@@ -168,11 +171,14 @@ def get_case_url(meta: Dict) -> str:
         return meta["url"]
     if "resource_uri" in meta:
         return meta["resource_uri"]
+    if "cluster_id" in meta:
+        return f"/clusters/{meta['cluster_id']}/"
     if "absolute_url" in meta:
         url = meta["absolute_url"]
-        if url.startswith("http"):
+        if url.startswith("/api/"):
             return url
-        return f"{API_BASE}{url}" if not url.startswith("/api") else url
+        if url.startswith("http") and "/api/" in url:
+            return url
     raise KeyError("No case URL found in metadata")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,6 +51,30 @@ def test_case_searcher_pagination():
     assert mock_client.get.call_count == 2
 
 
+def test_case_searcher_pagination_absolute_next():
+    mock_client = MagicMock()
+    first = MagicMock()
+    first.json.return_value = {
+        'results': [{'id': 1, 'url': '/case/1'}],
+        'next': 'https://example.com/api/search/?page=2'
+    }
+    first.content = b'{}'
+    second = MagicMock()
+    second.json.return_value = {
+        'results': [{'id': 2, 'url': '/case/2'}],
+        'next': None
+    }
+    second.content = b'{}'
+    mock_client.get.side_effect = [first, second]
+    searcher = CaseSearcher(mock_client)
+    results = list(searcher.search('kw'))
+    assert results == [
+        {'id': 1, 'url': '/case/1'},
+        {'id': 2, 'url': '/case/2'},
+    ]
+    assert mock_client.get.call_count == 2
+
+
 def test_api_client_retry(monkeypatch):
     responses = []
     first = MagicMock(status_code=429, headers={'Retry-After': '0'})
@@ -83,6 +107,36 @@ def test_case_downloader_download():
     mock_client.get.assert_called_with('/case/1')
 
 
+def test_case_downloader_absolute_url():
+    mock_client = MagicMock()
+    response = MagicMock()
+    response.json.return_value = {'foo': 'bar'}
+    response.content = b'{}'
+    mock_client.get.return_value = response
+    downloader = CaseDownloader(mock_client)
+    url = 'https://example.com/api/case/1'
+    result = downloader.download(url)
+    assert result == {'foo': 'bar'}
+    mock_client.get.assert_called_with(url)
+
+
+def test_api_client_absolute_path(monkeypatch):
+    called = {}
+
+    def fake_get(url, headers=None, params=None):
+        called['url'] = url
+        response = MagicMock(status_code=200)
+        response.content = b''
+        return response
+
+    import requests
+    monkeypatch.setattr(requests, 'get', fake_get)
+
+    client = ApiClient('http://example.com', 't')
+    client.get('https://foo.com/bar')
+    assert called['url'] == 'https://foo.com/bar'
+
+
 def test_get_case_id_variants():
     meta = {'id': 1, 'cluster_id': 2, 'docket_id': 3}
     assert get_case_id(meta) == '1'
@@ -95,10 +149,18 @@ def test_get_case_id_variants():
 def test_get_case_url_variants():
     assert get_case_url({'url': '/case/1'}) == '/case/1'
     assert get_case_url({'resource_uri': '/case/2'}) == '/case/2'
-    expected = f"{API_BASE}/case/3"
-    assert get_case_url({'absolute_url': '/case/3'}) == expected
+    assert get_case_url({'cluster_id': 3}) == '/clusters/3/'
+    assert (
+        get_case_url({'absolute_url': '/api/rest/v4/opinions/4/'})
+        == '/api/rest/v4/opinions/4/'
+    )
     with pytest.raises(KeyError):
-        get_case_url({})
+        get_case_url({'absolute_url': '/opinion/5'})
+
+
+def test_get_case_url_prefers_cluster_id():
+    meta = {'cluster_id': 42, 'absolute_url': '/opinion/42/foo'}
+    assert get_case_url(meta) == '/clusters/42/'
 
 
 def test_gui_download_cases_handles_cluster_id(tmp_path):


### PR DESCRIPTION
## Summary
- handle absolute URLs in ApiClient.get
- add regression tests for absolute URL handling
- fix get_case_url for cluster-only metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684ec706fe34832c8e7f37738c78815e