### PR TITLE
Fix date entry widget error and add filtering support

### DIFF
--- a/CourtListenerHelper.py
+++ b/CourtListenerHelper.py
@@ -102,6 +102,8 @@ class CaseSearcher:
         self,
         keyword: str,
         jurisdictions: Optional[Union[str, Iterable[str]]] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
     ) -> Generator[Dict, None, None]:
         """Yield search results for ``keyword`` filtered by jurisdictions."""
 
@@ -117,6 +119,11 @@ class CaseSearcher:
             else:
                 juris_val = ",".join(jurisdictions)
             params["jurisdiction"] = juris_val
+
+        if start_date:
+            params["date_filed_min"] = start_date
+        if end_date:
+            params["date_filed_max"] = end_date
 
         next_url = None
         keyword_lc = keyword.lower()


### PR DESCRIPTION
## Summary
- add start and end date fields to the GUI and properly pack the Entry widgets
- pass date values to the search routine
- allow `CaseSearcher.search` to filter by date
- clean up indentation of `run()`

## Testing
- `pip install requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851df0b3348832ca6d719df518b7baf