### PR TITLE
Remove redundant keyword filtering

### DIFF
--- a/CourtListenerHelper.py
+++ b/CourtListenerHelper.py
@@ -107,7 +107,7 @@ class CaseSearcher:
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> Generator[Dict, None, None]:
-        """Yield search results that contain ``keyword`` in the metadata or opinions."""
+        """Yield search results for ``keyword`` with optional filters."""
 
         path = "/search/"
         params = {
@@ -125,7 +125,6 @@ class CaseSearcher:
         if end_date:
             params["filed_before"] = end_date
 
-        keyword_lc = keyword.lower()
         next_url: Optional[str] = None
 
         while True:
@@ -134,16 +133,7 @@ class CaseSearcher:
             js = resp.json()
 
             for result in js.get("results", []):
-                text = f"{result.get('name', '')} {result.get('snippet', '')}".lower()
-                if keyword_lc in text:
-                    yield result
-                    continue
-
-                for op in result.get("opinions", []):
-                    op_text = f"{op.get('name', '')} {op.get('snippet', '')}".lower()
-                    if keyword_lc in op_text:
-                        yield result
-                        break
+                yield result
 
             next_url = js.get("next")
             if not next_url:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,7 +86,9 @@ def test_case_searcher_keyword_filter_excludes_non_matching():
     mock_client.get.return_value = resp
     searcher = CaseSearcher(mock_client)
     results = list(searcher.search('target'))
-    assert results == []
+    assert results == [
+        {'id': 3, 'url': '/case/3', 'name': 'other case'}
+    ]
     mock_client.get.assert_called_once()
 
 


### PR DESCRIPTION
## Summary
- stop filtering search results since API already handles keyword filtering
- update docstring and tests accordingly

## Testing
- `pip install requests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d055d88c832caf14900aa2760687