### PR TITLE
Return full case metadata with opinions

### DIFF
--- a/CourtListenerHelper.py
+++ b/CourtListenerHelper.py
@@ -147,20 +147,19 @@ class CaseDownloader:
         self.client = client
 
     def download_opinions(self, case_meta: Dict) -> Dict:
-        """Return opinion texts for the case described by ``case_meta``."""
+        """Return full case metadata and associated opinion texts."""
 
         case_id = get_case_id(case_meta)
         case_url = get_case_url(case_meta)
         resp = self.client.get(case_url)
-        case_data = resp.json()
+        full_meta = resp.json()
 
-        cluster_id = case_data.get("cluster_id")
+        cluster_id = full_meta.get("cluster_id")
         opinions = self._fetch_opinions(cluster_id)
 
         return {
             "case_id": case_id,
-            "name": case_data.get("name"),
-            "cluster_id": cluster_id,
+            "case_meta": full_meta,
             "opinions": opinions,
         }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -132,8 +132,7 @@ def test_case_downloader_download():
     result = downloader.download_opinions({'id': 1, 'url': '/case/1'})
     assert result == {
         'case_id': '1',
-        'name': 'n',
-        'cluster_id': 1,
+        'case_meta': {'name': 'n', 'cluster_id': 1},
         'opinions': [{'id': 1}],
     }
     mock_client.get.assert_called_with('/case/1')
@@ -151,8 +150,7 @@ def test_case_downloader_absolute_url():
     result = downloader.download_opinions({'id': 1, 'url': url})
     assert result == {
         'case_id': '1',
-        'name': 'n',
-        'cluster_id': 5,
+        'case_meta': {'name': 'n', 'cluster_id': 5},
         'opinions': [],
     }
     mock_client.get.assert_called_with(url)


### PR DESCRIPTION
## Summary
- update `CaseDownloader.download_opinions` to return full case metadata
- adjust unit tests for the new structure

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d6ab189c832c9b29747c04803c9d