### PR TITLE
Add sub opinion downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ front ends.
 
 - Search the CourtListener API by keyword
 - Download full case metadata in JSON format
+- Download any sub-opinion JSON referenced by an opinion
 - Download the associated opinion PDF when available
 - Retrieve docket PDFs via the RECAP system
 - Command line and graphical interfaces


### PR DESCRIPTION
## Summary
- fetch sub-opinion JSON via new helper functions
- note sub-opinion downloading in README
- test fetching of sub-opinion data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560588ba3c832c81b0504fd132ca84