### PR TITLE
Fix fallback to cluster id when missing

### DIFF
--- a/CourtListenerHelper.py
+++ b/CourtListenerHelper.py
@@ -154,7 +154,10 @@ class CaseDownloader:
         resp = self.client.get(case_url)
         full_meta = resp.json()
 
-        cluster_id = full_meta.get("cluster_id")
+        # Some cluster detail responses omit ``cluster_id`` and only include
+        # ``id``. Fall back to the ``id`` field so opinions can still be
+        # retrieved for such cases.
+        cluster_id = full_meta.get("cluster_id") or full_meta.get("id")
         opinions = self._fetch_opinions(cluster_id)
 
         return {

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -156,6 +156,25 @@ def test_case_downloader_absolute_url():
     mock_client.get.assert_called_with(url)
 
 
+def test_case_downloader_missing_cluster_id_uses_id():
+    """download_opinions should fall back to 'id' when 'cluster_id' is absent."""
+    mock_client = MagicMock()
+    response = MagicMock()
+    response.json.return_value = {'name': 'n', 'id': 7}
+    response.content = b'{}'
+    mock_client.get.return_value = response
+    downloader = CaseDownloader(mock_client)
+    downloader._fetch_opinions = MagicMock(return_value=[])
+    result = downloader.download_opinions({'id': 7, 'url': '/case/7'})
+
+    assert result == {
+        'case_id': '7',
+        'case_meta': {'name': 'n', 'id': 7},
+        'opinions': [],
+    }
+    downloader._fetch_opinions.assert_called_with(7)
+
+
 def test_fetch_opinions_fetches_sub_opinions():
     client = MagicMock()
     main_resp = MagicMock()


### PR DESCRIPTION
## Summary
- fetch opinions using `id` when `cluster_id` isn't provided
- test downloader handles missing `cluster_id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a56d93e4832c915757582eab26fd